### PR TITLE
fix: Update Node engine to 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=14.0"
+    "node": ">=18.0"
   },
   "scripts": {
     "build": "npm run codegen && tsc",


### PR DESCRIPTION
Most new services probably want 18, this should match `@types/node`, and advanced users can always downgrade if they know what they need.